### PR TITLE
Docker container for Ultrastar-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ The first run will check yt-dlp and initialize a session. Use the search form, p
 Run Ultrastar-CLI via docker (requires docker installation).
 
 ### Setup
-1. clone this repository
+1. Clone this repository.
 ```
 mkdir -p "${HOME}/Ultrastar-CLI"
-cd ${HOME}/Ultrastar-CLI || exit
+cd "${HOME}/Ultrastar-CLI" || exit
 git clone https://github.com/martiinii/UltraStar-CLI.git
 ```
 
-2. Build the docker container:
+2. Build the docker container.
+Set the number of CPUs to what you have available.
 ```
 cd "${HOME}/UltraStar-CLI/Ultrastar-CLI" || exit
 docker build \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ bunx --bun ultrastar
 The first run will check yt-dlp and initialize a session. Use the search form, pick a song, and press Enter to download. Your songs will be saved under `./songs/Artist - Title/`.
 
 
+## Docker
+Run Ultrastar-CLI via docker (requires docker installation).
+
+### Setup
+1. clone this repository
+```
+mkdir -p "${HOME}/Ultrastar-CLI"
+cd ${HOME}/Ultrastar-CLI || exit
+git clone https://github.com/martiinii/UltraStar-CLI.git
+```
+
+2. Build the docker container:
+```
+cd "${HOME}/UltraStar-CLI/Ultrastar-CLI" || exit
+docker build \
+       -t martiinii/ultrastar-cli \
+       . \
+       --cpuset-cpus 10
+```
+
+### Run Ultrastar-CLI via docker
+```
+# Environment
+dir="${HOME}/UltraStar-CLI"
+mkdir -p "${dir}/"{songs,config}
+
+# Run the docker container interactively
+docker \
+    run \
+    --rm -it \
+    --user "$(id -u):$(id -g)" \
+    -v "${dir}/songs":/app/songs \
+    -v "${dir}/config":/app/.config \
+    martiinii/ultrastar-cli:latest
+```
+
 ## Keyboard Shortcuts
 - In search form: Tab = switch field, Enter = search, Esc = quit
 - In results: ↑/↓ = select, Enter = download, ←/→ = page, e = edit search, r = refresh, Esc = back

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,23 @@
+FROM oven/bun:alpine
+WORKDIR /app
+
+# System dependencies required by yt-dlp / ffmpeg
+RUN apk add --no-cache python3 py3-pip ffmpeg ca-certificates tzdata bash
+
+# Install youtube-dl
+RUN python3 -m venv /opt/yt-venv && \
+    /opt/yt-venv/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    /opt/yt-venv/bin/pip install --no-cache-dir yt-dlp && \
+    ln -s /opt/yt-venv/bin/yt-dlp /usr/local/bin/yt-dlp
+
+ENV PATH="/opt/yt-venv/bin:${PATH}"
+
+COPY . .
+RUN bun install && bun run build
+
+RUN addgroup -S app && adduser -S app -G app
+USER app
+
+VOLUME ["/app/songs", "/app/.config"]
+ENTRYPOINT ["bunx", "--bun", "ultrastar"]
+CMD ["--help"]


### PR DESCRIPTION
This pull request adds a dockerfile (recipe) and edits to the README.md to explain how to build the Ultrastar-CLI docker container and subsequently run it. 

Providing a docker container makes it much easier to install across multiple systems, especially older systems that may not have all the required packages available for bun or npx.